### PR TITLE
ios: Replace hard-coded status banner with real connection status

### DIFF
--- a/ios/HealthBridgeApp/HealthBridgeApp.swift
+++ b/ios/HealthBridgeApp/HealthBridgeApp.swift
@@ -12,6 +12,7 @@ import HealthKit
 import CryptoKit
 import HealthBridgeKit
 import UserNotifications
+import Network
 import OSLog
 
 /// All HealthKit + drain-loop diagnostics flow through this logger.
@@ -117,8 +118,8 @@ final class AppCoordinator: ObservableObject {
         case denied(String)
     }
 
-    @Published var status: String = "Starting up…"
-    @Published var lastError: String?
+    @Published var connectionStatus: ConnectionStatus = .notPaired
+    @Published var networkAvailable: Bool = true
     @Published var drainedCount: Int = 0
     @Published var auth: AuthState = .unknown
     /// The currently-paired Mac, if any. nil = no pair on disk yet,
@@ -138,11 +139,18 @@ final class AppCoordinator: ObservableObject {
     private var pushDrainRequested = false
     private let store = HKHealthStore()
     private let authStateStore = AuthStateStore()
+    private let networkMonitor = NWPathMonitor()
 
     init() {
         self.auditLog = AuditLog(fileURL: Self.auditLogURL())
         self.pair = PairStorage.load()
         self.auth = authStateStore.load()
+        networkMonitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor [weak self] in
+                self?.networkAvailable = path.status == .satisfied
+            }
+        }
+        networkMonitor.start(queue: DispatchQueue(label: "li.shuyang.healthbridge.netmon"))
         Task { @MainActor [weak self] in
             guard let self else { return }
             if let entries = try? await self.auditLog.all() {
@@ -212,7 +220,7 @@ final class AppCoordinator: ObservableObject {
         stopDrainLoop()
         try? PairStorage.clear()
         self.pair = nil
-        self.status = "Unpaired. Run `healthbridge pair` on your Mac to pair again."
+        self.connectionStatus = .notPaired
     }
 
     // MARK: - Authorisation (called from a button tap)
@@ -228,13 +236,13 @@ final class AppCoordinator: ObservableObject {
         log.info("HKHealthStore.isHealthDataAvailable() = \(available, privacy: .public)")
         guard available else {
             auth = .unavailable
-            status = "HealthKit is not available on this device."
+            connectionStatus = .relayError("HealthKit is not available on this device.")
             log.error("HealthKit reports unavailable — likely an iOS Simulator without HealthKit, or a non-iPhone device")
             return
         }
 
         auth = .requesting
-        status = "Asking HealthKit for permission…"
+        connectionStatus = .connecting
         log.info("transitioning to .requesting; will call HKHealthStore.requestAuthorization next")
 
         Task { @MainActor in
@@ -242,9 +250,7 @@ final class AppCoordinator: ObservableObject {
                 try await self.requestAuthorization()
                 self.auth = .authorized
                 self.authStateStore.save(.authorized)
-                self.status = self.pair == nil
-                    ? "Connected — pair with your computer to start draining."
-                    : "Connected — draining relay"
+                self.connectionStatus = self.pair == nil ? .notPaired : .connected
                 log.info("requestAuthorization returned successfully; transitioning to .authorized")
                 if self.pair != nil {
                     self.startDrainLoopIfNeeded()
@@ -252,8 +258,7 @@ final class AppCoordinator: ObservableObject {
             } catch {
                 self.auth = .denied("\(error)")
                 self.authStateStore.save(self.auth)
-                self.lastError = "\(error)"
-                self.status = "HealthKit permission failed: \(error.localizedDescription)"
+                self.connectionStatus = .relayError("HealthKit permission failed: \(error.localizedDescription)")
                 log.error("requestAuthorization threw: \(error.localizedDescription, privacy: .public)")
             }
         }
@@ -291,14 +296,14 @@ final class AppCoordinator: ObservableObject {
             log.info("startDrainLoopIfNeeded: no pair — skipping")
             return
         }
+        connectionStatus = .connecting
         drainTask = Task { @MainActor in
             do {
                 try await self.drainLoop(pair: pair)
-            } catch is CancellationError {
-                // expected on backgrounding
             } catch {
-                self.lastError = "\(error)"
-                self.status = "Drain stopped: \(error.localizedDescription)"
+                if let status = classifyDrainError( error) {
+                    self.connectionStatus = status
+                }
             }
             self.drainTask = nil
         }
@@ -308,7 +313,7 @@ final class AppCoordinator: ObservableObject {
         drainTask?.cancel()
         drainTask = nil
         if case .authorized = auth, pair != nil {
-            status = "Backgrounded — waiting for push."
+            connectionStatus = .backgrounded
         }
     }
 
@@ -425,11 +430,11 @@ final class AppCoordinator: ObservableObject {
 
     private func drainLoop(pair startingPair: StoredPair) async throws {
         guard let relayURL = URL(string: startingPair.relayURL) else {
-            self.status = "Invalid relay URL in stored pair."
+            self.connectionStatus = .relayError("Invalid relay URL in stored pair.")
             return
         }
         guard let keyBytes = Data(hexString: startingPair.sessionKeyHex), keyBytes.count == 32 else {
-            self.status = "Invalid session key in stored pair — re-pair from your Mac."
+            self.connectionStatus = .relayError("Invalid session key in stored pair — re-pair from your Mac.")
             return
         }
         let session = JobsSession(key: SymmetricKey(data: keyBytes), pairID: startingPair.pairID)
@@ -457,6 +462,7 @@ final class AppCoordinator: ObservableObject {
         log.info("drainLoop start cursor=\(cursor, privacy: .public)")
         while !Task.isCancelled {
             let page = try await client.pollJobs(sinceMs: cursor, waitMs: 25_000)
+            self.connectionStatus = .connected
             for jb in page.jobs {
                 let outcome = await self.processOneJob(jb: jb, session: session, client: client)
                 switch outcome {
@@ -1034,21 +1040,9 @@ struct ContentView: View {
                 .padding(.top, 8)
 
             // Status banner
-            HStack(spacing: 6) {
-                Circle()
-                    .fill(.green)
-                    .frame(width: 8, height: 8)
-                Text("STATUS: CONNECTED")
-                    .font(.system(size: 12, weight: .semibold))
-                    .tracking(0.8)
-                    .foregroundStyle(.green)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
-            .background(Color.green.opacity(0.1))
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .padding(.horizontal, 24)
-            .padding(.top, 16)
+            statusBanner
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
 
             // Section header
             Text("Activity Log")
@@ -1060,6 +1054,38 @@ struct ContentView: View {
             // Log entries
             ActivityLogView(entries: coordinator.auditEntries)
         }
+    }
+
+    private var effectiveStatus: ConnectionStatus {
+        effectiveConnectionStatus(
+            base: coordinator.connectionStatus,
+            networkAvailable: coordinator.networkAvailable
+        )
+    }
+
+    private var statusBanner: some View {
+        let status = effectiveStatus
+        let (color, label): (Color, String) = switch status {
+        case .connected:          (.green,  "STATUS: CONNECTED")
+        case .connecting:         (.yellow, "STATUS: CONNECTING")
+        case .backgrounded:       (.yellow, "STATUS: BACKGROUNDED")
+        case .notPaired:          (.gray,   "STATUS: NOT PAIRED")
+        case .networkUnavailable: (.red,    "STATUS: NO NETWORK")
+        case .relayError:         (.red,    "STATUS: ERROR")
+        }
+        return HStack(spacing: 6) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.system(size: 12, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(color)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .background(color.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
     private func makePairingModel() -> PairingFlowModel {

--- a/ios/HealthBridgeApp/HealthBridgeApp.swift
+++ b/ios/HealthBridgeApp/HealthBridgeApp.swift
@@ -145,6 +145,7 @@ final class AppCoordinator: ObservableObject {
         self.auditLog = AuditLog(fileURL: Self.auditLogURL())
         self.pair = PairStorage.load()
         self.auth = authStateStore.load()
+        self.connectionStatus = self.pair != nil ? .backgrounded : .notPaired
         networkMonitor.pathUpdateHandler = { [weak self] path in
             Task { @MainActor [weak self] in
                 self?.networkAvailable = path.status == .satisfied
@@ -296,7 +297,7 @@ final class AppCoordinator: ObservableObject {
             log.info("startDrainLoopIfNeeded: no pair — skipping")
             return
         }
-        connectionStatus = .connecting
+        connectionStatus = .connected
         drainTask = Task { @MainActor in
             do {
                 try await self.drainLoop(pair: pair)
@@ -462,7 +463,6 @@ final class AppCoordinator: ObservableObject {
         log.info("drainLoop start cursor=\(cursor, privacy: .public)")
         while !Task.isCancelled {
             let page = try await client.pollJobs(sinceMs: cursor, waitMs: 25_000)
-            self.connectionStatus = .connected
             for jb in page.jobs {
                 let outcome = await self.processOneJob(jb: jb, session: session, client: client)
                 switch outcome {

--- a/ios/Sources/HealthBridgeKit/ConnectionStatus.swift
+++ b/ios/Sources/HealthBridgeKit/ConnectionStatus.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The app's connection status, derived from pairing state, drain-loop
+/// activity, and network reachability. Defined in the kit so it can be
+/// unit-tested without HealthKit or UIKit dependencies.
+public enum ConnectionStatus: Equatable, Sendable {
+    case notPaired
+    case connecting
+    case connected
+    case backgrounded
+    case networkUnavailable
+    case relayError(String)
+}
+
+/// Maps a drain-loop error to a ``ConnectionStatus``.
+///
+/// Returns `nil` for cancellation errors (structured-concurrency or
+/// URLSession-level) that should be silently ignored.
+public func classifyDrainError(_ error: Error) -> ConnectionStatus? {
+    if error is CancellationError {
+        return nil
+    }
+    if let urlError = error as? URLError {
+        if urlError.code == .cancelled {
+            return nil
+        }
+        if [.notConnectedToInternet, .networkConnectionLost, .dataNotAllowed]
+            .contains(urlError.code) {
+            return .networkUnavailable
+        }
+    }
+    return .relayError(error.localizedDescription)
+}
+
+/// Overlays NWPathMonitor reachability on top of the base connection status.
+/// When the network is down and the base status is `.connected` or
+/// `.connecting`, returns `.networkUnavailable` for instant UI feedback
+/// before the HTTP request times out.
+public func effectiveConnectionStatus(
+    base: ConnectionStatus,
+    networkAvailable: Bool
+) -> ConnectionStatus {
+    guard !networkAvailable else { return base }
+    switch base {
+    case .connected, .connecting:
+        return .networkUnavailable
+    default:
+        return base
+    }
+}

--- a/ios/Tests/HealthBridgeKitTests/ConnectionStatusTests.swift
+++ b/ios/Tests/HealthBridgeKitTests/ConnectionStatusTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import HealthBridgeKit
+
+final class ConnectionStatusTests: XCTestCase {
+
+    // MARK: - effectiveConnectionStatus
+
+    func testEffectiveStatus_networkAvailable_passesThrough() {
+        for base: ConnectionStatus in [
+            .notPaired, .connecting, .connected,
+            .backgrounded, .networkUnavailable,
+            .relayError("boom"),
+        ] {
+            XCTAssertEqual(
+                effectiveConnectionStatus(base: base, networkAvailable: true),
+                base,
+                "should pass through \(base) when network is available"
+            )
+        }
+    }
+
+    func testEffectiveStatus_networkDown_overridesConnectedAndConnecting() {
+        XCTAssertEqual(
+            effectiveConnectionStatus(base: .connected, networkAvailable: false),
+            .networkUnavailable
+        )
+        XCTAssertEqual(
+            effectiveConnectionStatus(base: .connecting, networkAvailable: false),
+            .networkUnavailable
+        )
+    }
+
+    func testEffectiveStatus_networkDown_preservesOtherStates() {
+        for base: ConnectionStatus in [
+            .notPaired, .backgrounded, .networkUnavailable,
+            .relayError("x"),
+        ] {
+            XCTAssertEqual(
+                effectiveConnectionStatus(base: base, networkAvailable: false),
+                base,
+                "should preserve \(base) when network is down"
+            )
+        }
+    }
+
+    // MARK: - classifyDrainError()
+
+    func testDrainError_cancellationError_returnsNil() {
+        let err = CancellationError()
+        XCTAssertNil(classifyDrainError( err))
+    }
+
+    func testDrainError_urlErrorCancelled_returnsNil() {
+        let err = URLError(.cancelled)
+        XCTAssertNil(classifyDrainError( err))
+    }
+
+    func testDrainError_notConnectedToInternet_returnsNetworkUnavailable() {
+        let err = URLError(.notConnectedToInternet)
+        XCTAssertEqual(classifyDrainError( err), .networkUnavailable)
+    }
+
+    func testDrainError_networkConnectionLost_returnsNetworkUnavailable() {
+        let err = URLError(.networkConnectionLost)
+        XCTAssertEqual(classifyDrainError( err), .networkUnavailable)
+    }
+
+    func testDrainError_dataNotAllowed_returnsNetworkUnavailable() {
+        let err = URLError(.dataNotAllowed)
+        XCTAssertEqual(classifyDrainError( err), .networkUnavailable)
+    }
+
+    func testDrainError_otherURLError_returnsRelayError() {
+        let err = URLError(.badServerResponse)
+        let result = classifyDrainError( err)
+        guard case .relayError = result else {
+            XCTFail("expected .relayError, got \(String(describing: result))")
+            return
+        }
+    }
+
+    func testDrainError_arbitraryError_returnsRelayError() {
+        struct TestError: Error, LocalizedError {
+            var errorDescription: String? { "test failure" }
+        }
+        let result = classifyDrainError(TestError())
+        XCTAssertEqual(result, ConnectionStatus.relayError("test failure"))
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the always-green "STATUS: CONNECTED" banner with a dynamic banner that reflects actual connection state
- Add `ConnectionStatus` enum: `notPaired`, `connecting`, `connected`, `backgrounded`, `networkUnavailable`, `relayError`
- Add `NWPathMonitor` for instant network-down UI feedback (display-only — does not gate the drain loop)
- Discriminate drain-loop errors: `CancellationError` and `URLError.cancelled` are silently ignored; network errors (`notConnectedToInternet`, `networkConnectionLost`, `dataNotAllowed`) map to `.networkUnavailable`; everything else maps to `.relayError`
- Extract pure functions into HealthBridgeKit for testability: `classifyDrainError()` and `effectiveConnectionStatus()`

## Test plan

- [x] 10 new unit tests covering error classification and effective status overlay logic (63 total, all passing)
- [x] Xcode build succeeds (`xcodebuild build -scheme HealthBridge`)
- [x] Manual: launch unpaired → gray "NOT PAIRED"
- [x] Manual: pair → green "CONNECTED"
- [x] Manual: background app → yellow "BACKGROUNDED"
- [x] Manual: airplane mode → red "NO NETWORK"
- [x] Manual: foreground again → green "CONNECTED"

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)