### PR TITLE
ios: cap activity log to last 50 entries

### DIFF
--- a/ios/HealthBridgeApp/ActivityLogView.swift
+++ b/ios/HealthBridgeApp/ActivityLogView.swift
@@ -7,7 +7,13 @@ import SwiftUI
 import HealthBridgeKit
 
 struct ActivityLogView: View {
+    static let displayLimit = 50
+
     let entries: [AuditEntry]
+
+    private var visibleEntries: [AuditEntry] {
+        entries.suffix(Self.displayLimit).reversed()
+    }
 
     var body: some View {
         if entries.isEmpty {
@@ -19,10 +25,17 @@ struct ActivityLogView: View {
         } else {
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    ForEach(entries.reversed(), id: \.id) { entry in
+                    ForEach(visibleEntries, id: \.id) { entry in
                         ActivityLogRow(entry: entry)
                         Divider()
                             .padding(.leading, 52)
+                    }
+                    if entries.count > Self.displayLimit {
+                        Text("Only the last \(Self.displayLimit) activities are shown.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
                     }
                 }
             }

--- a/ios/HealthBridgeApp/HealthBridgeApp.swift
+++ b/ios/HealthBridgeApp/HealthBridgeApp.swift
@@ -146,7 +146,7 @@ final class AppCoordinator: ObservableObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
             if let entries = try? await self.auditLog.all() {
-                self.auditEntries = entries.suffix(ActivityLogView.displayLimit)
+                self.auditEntries = entries
             }
         }
     }
@@ -556,8 +556,8 @@ final class AppCoordinator: ObservableObject {
         )
         try? await auditLog.append(entry)
         auditEntries.append(entry)
-        if auditEntries.count > ActivityLogView.displayLimit {
-            auditEntries.removeFirst(auditEntries.count - ActivityLogView.displayLimit)
+        if auditEntries.count > AuditLog.maxEntries {
+            auditEntries.removeFirst(auditEntries.count - AuditLog.maxEntries)
         }
     }
 

--- a/ios/HealthBridgeApp/HealthBridgeApp.swift
+++ b/ios/HealthBridgeApp/HealthBridgeApp.swift
@@ -146,7 +146,7 @@ final class AppCoordinator: ObservableObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
             if let entries = try? await self.auditLog.all() {
-                self.auditEntries = entries
+                self.auditEntries = entries.suffix(ActivityLogView.displayLimit)
             }
         }
     }
@@ -556,8 +556,8 @@ final class AppCoordinator: ObservableObject {
         )
         try? await auditLog.append(entry)
         auditEntries.append(entry)
-        if auditEntries.count > AuditLog.maxEntries {
-            auditEntries.removeFirst(auditEntries.count - AuditLog.maxEntries)
+        if auditEntries.count > ActivityLogView.displayLimit {
+            auditEntries.removeFirst(auditEntries.count - ActivityLogView.displayLimit)
         }
     }
 


### PR DESCRIPTION
## Summary

- Cap the in-memory `auditEntries` list to 50 entries (down from 1000) so it doesn't grow unbounded at runtime
- Only display the last 50 entries in the Activity Log UI
- Show a "Only the last 50 activities are shown." disclaimer footer when there are more than 50 total entries
- On-disk `AuditLog` retains its 1000-entry cap for full audit trail

## Test plan

- [ ] Verify activity log shows at most 50 entries
- [ ] Verify disclaimer footer appears when entries exceed 50
- [ ] Verify disclaimer footer is hidden when entries are 50 or fewer
- [ ] Verify new entries still append correctly and oldest are trimmed from the in-memory list

🤖 Generated with [Claude Code](https://claude.com/claude-code)