### PR TITLE
docs: add onboarding sections and parameterize iOS signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,48 @@ You'll need to set up your own Cloudflare Worker as the relay — see
 is a dumb store-and-forward mailbox that only ever sees ciphertext, so
 running your own instance is the safest deployment.
 
+To enable push notifications (so the iOS app wakes up automatically
+when a job is enqueued), you'll also need an Apple Developer account
+and an APNs authentication key — see the
+[APNs setup section](relay/README.md#apple-push-notifications-apns) in
+the relay README.
+
+## Install the iOS app
+
+The iOS app is not on the App Store — side-load it onto your iPhone
+by building from Xcode. An Apple Developer account (free or paid) is
+required for signing.
+
+```sh
+cd ios
+
+# Set your signing identity and bundle ID:
+export HEALTHBRIDGE_TEAM_ID="<your Apple Developer Team ID>"
+export HEALTHBRIDGE_BUNDLE_ID_PREFIX="com.<yourname>"
+export HEALTHBRIDGE_BUNDLE_ID="com.<yourname>.HealthBridge"
+
+# Generate the Xcode project and open it:
+xcodegen
+open HealthBridge.xcodeproj
+```
+
+Then connect your iPhone (or select it under *Destination*) and hit
+**Cmd+R** to build and run.
+
+See [`ios/README.md`](ios/README.md) for more details.
+
+## Install the agent skill
+
+After installing the CLI, add the HealthBridge agent skill so your AI
+agent knows how to drive it:
+
+```sh
+npx skills add ./skill/healthbridge
+```
+
+See [`skill/healthbridge/README.md`](skill/healthbridge/README.md) for
+alternative install methods and agent-specific options.
+
 `brew upgrade healthbridge` picks up future releases.
 
 Linux users and anyone who wants a tarball can grab one from

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ You'll need to set up your own Cloudflare Worker as the relay — see
 is a dumb store-and-forward mailbox that only ever sees ciphertext, so
 running your own instance is the safest deployment.
 
-To enable push notifications (so the iOS app wakes up automatically
-when a job is enqueued), you'll also need an Apple Developer account
-and an APNs authentication key — see the
+Optionally, you can enable push notifications so the iOS app wakes up
+automatically when a job is enqueued. This requires an Apple Developer
+account and an APNs authentication key — see the
 [APNs setup section](relay/README.md#apple-push-notifications-apns) in
-the relay README.
+the relay README. Without push notifications the app falls back to
+polling when foregrounded.
 
 ## Install the iOS app
 

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -12,7 +12,7 @@ name: HealthBridge
 # CODE_SIGN_ENTITLEMENTS in the target's build settings.
 
 options:
-  bundleIdPrefix: li.shuyang.healthbridge
+  bundleIdPrefix: ${HEALTHBRIDGE_BUNDLE_ID_PREFIX}
   deploymentTarget:
     iOS: "18.0"
   xcodeVersion: "16.0"
@@ -22,10 +22,10 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.9"
-    # Personal Apple developer team. The ID isn't a secret — it's
-    # visible in any signed app bundle's entitlements — but if you fork
-    # this repo you'll want to swap in your own.
-    DEVELOPMENT_TEAM: RM2BB7S3BX
+    # Set HEALTHBRIDGE_TEAM_ID and HEALTHBRIDGE_BUNDLE_ID in your
+    # environment before running `xcodegen` to use your own signing
+    # identity and bundle ID.
+    DEVELOPMENT_TEAM: ${HEALTHBRIDGE_TEAM_ID}
     CODE_SIGN_STYLE: Automatic
     ENABLE_USER_SCRIPT_SANDBOXING: YES
     SWIFT_TREAT_WARNINGS_AS_ERRORS: NO
@@ -49,7 +49,7 @@ targets:
           - "HealthBridge.entitlements"
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: li.shuyang.healthbridge
+        PRODUCT_BUNDLE_IDENTIFIER: ${HEALTHBRIDGE_BUNDLE_ID}
         INFOPLIST_FILE: HealthBridgeApp/Info.plist
         CODE_SIGN_ENTITLEMENTS: HealthBridgeApp/HealthBridge.entitlements
         TARGETED_DEVICE_FAMILY: "1,2"

--- a/relay/README.md
+++ b/relay/README.md
@@ -81,6 +81,43 @@ a matching `X-Relay-Secret` header. The CLI reads the secret from
 app sends it automatically. Post-pairing endpoints are unaffected —
 they use the per-pair Bearer token.
 
+### Apple Push Notifications (APNs)
+
+The relay can send push notifications to the iOS app so it wakes up
+and drains the job mailbox without the user having to open the app
+manually. This requires an Apple Developer account and a few secrets
+pushed to Cloudflare.
+
+1. **Create an APNs authentication key** in the
+   [Apple Developer portal](https://developer.apple.com/account/resources/authkeys/list):
+   - Go to *Certificates, Identifiers & Keys* → *Keys* → **+**.
+   - Enable *Apple Push Notifications service (APNs)*.
+   - Download the `.p8` file — you get **one chance** to download it.
+   - Note the **Key ID** shown after creation and your **Team ID**
+     (top-right of the portal, or *Membership* → *Team ID*).
+
+2. **Push the secrets to Cloudflare:**
+
+   ```sh
+   # The .p8 file contents (include the BEGIN/END lines).
+   npx wrangler secret put APNS_AUTH_KEY < AuthKey_XXXXXXXXXX.p8
+
+   # The iOS app's bundle identifier — must match HEALTHBRIDGE_BUNDLE_ID
+   # you used when building the iOS app with xcodegen.
+   npx wrangler secret put APNS_BUNDLE_ID
+
+   # The Key ID from step 1.
+   npx wrangler secret put APNS_KEY_ID
+
+   # Your Apple Developer Team ID.
+   npx wrangler secret put APNS_TEAM_ID
+   ```
+
+When all four secrets are set, the relay sends a background push to
+the paired device whenever a new job is enqueued. If any secret is
+missing, the relay silently skips the push and the app falls back to
+polling when foregrounded.
+
 ## API
 
 ```

--- a/relay/README.md
+++ b/relay/README.md
@@ -33,7 +33,7 @@ npx wrangler dev  # spawns workerd locally on http://127.0.0.1:8787
 The relay is designed to be self-hosted — there is no shared
 "healthbridge.example" instance. Each user runs their own Worker on
 their own Cloudflare account. The relay only ever sees ciphertext
-(M2+), so this is the safest deployment.
+so this is the safest deployment.
 
 Cloudflare's free plan is sufficient — Durable Objects on the free
 tier work as long as the DO classes are SQLite-backed, which this


### PR DESCRIPTION
## Summary

- Add **Install the iOS app** section to the main README with `xcodegen` side-loading instructions
- Add **Install the agent skill** section for `npx skills add`
- Add **APNs setup** documentation to the relay README with step-by-step instructions for configuring push notification secrets (`APNS_AUTH_KEY`, `APNS_BUNDLE_ID`, `APNS_KEY_ID`, `APNS_TEAM_ID`)
- Replace hard-coded `DEVELOPMENT_TEAM`, `PRODUCT_BUNDLE_IDENTIFIER`, and `bundleIdPrefix` in `ios/project.yml` with environment variables (`HEALTHBRIDGE_TEAM_ID`, `HEALTHBRIDGE_BUNDLE_ID`, `HEALTHBRIDGE_BUNDLE_ID_PREFIX`) so forks don't leak the original developer identity

## Test plan

- [x] Verify `xcodegen` generates a valid project with the env vars set
- [x] Verify the relay README APNs section renders correctly on GitHub
- [x] Confirm links between main README and relay README resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)